### PR TITLE
chore: namespace IndexedDB, polish spirit search UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ node_modules/
 
 # Build
 dist/
-.wrangler/
 .tanstack/
 
 # Environment

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -5,7 +5,6 @@
   "ignore": [
     "**/node_modules/**",
     "**/dist/**",
-    "**/.wrangler/**",
     "**/convex/_generated/**",
     "**/*.d.ts",
     "**/pnpm-lock.yaml",

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -4,7 +4,7 @@ const config: KnipConfig = {
   entry: ['src/main.tsx', 'src/sw.ts', 'convex/**/*.ts', 'scripts/*.ts'],
   project: ['src/**/*.{ts,tsx}', 'convex/**/*.ts'],
   ignore: ['src/routeTree.gen.ts', 'convex/_generated/**', 'src/components/ui/**'],
-  ignoreDependencies: ['tailwindcss', '@tailwindcss/vite', 'workbox-core'],
+  ignoreDependencies: ['tailwindcss'],
 }
 
 export default config

--- a/src/components/spirits/spirit-search.tsx
+++ b/src/components/spirits/spirit-search.tsx
@@ -1,4 +1,5 @@
 import { Search } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 
 interface SpiritSearchProps {
   value: string
@@ -6,15 +7,36 @@ interface SpiritSearchProps {
 }
 
 export function SpiritSearch({ value, onChange }: SpiritSearchProps) {
+  const [localValue, setLocalValue] = useState(value)
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null)
+
+  // Sync prop → local state (initial load, back navigation, external clear)
+  useEffect(() => {
+    setLocalValue(value)
+  }, [value])
+
+  const handleChange = (newValue: string) => {
+    setLocalValue(newValue)
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => onChange(newValue), 300)
+  }
+
+  // Clean up timer on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
   return (
     <div className="relative">
       <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
       <input
-        className="w-full pl-10 pr-4 py-2 rounded-lg border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
-        onChange={(e) => onChange(e.target.value)}
+        className="w-full h-10 pl-10 pr-4 rounded-lg border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+        onChange={(e) => handleChange(e.target.value)}
         placeholder="Search spirits..."
         type="search"
-        value={value}
+        value={localValue}
       />
     </div>
   )

--- a/src/components/ui/page-header.tsx
+++ b/src/components/ui/page-header.tsx
@@ -13,6 +13,8 @@ export interface PageHeaderProps {
   backHref?: string
   /** Optional view transition name for the header element */
   viewTransitionName?: string
+  /** Optional content rendered in the center of the header (e.g. search bar) */
+  center?: React.ReactNode
   /** Optional action elements (filter buttons, etc.) rendered on the right */
   children?: React.ReactNode
   /** Additional className for the header */
@@ -23,6 +25,7 @@ export function PageHeader({
   title,
   backHref,
   viewTransitionName,
+  center,
   children,
   className,
 }: PageHeaderProps) {
@@ -34,8 +37,8 @@ export function PageHeader({
       )}
       style={viewTransitionName ? { viewTransitionName } : undefined}
     >
-      <div className="flex items-center justify-between min-h-[44px]">
-        <div className="flex items-center gap-3">
+      <div className="flex items-center gap-4 min-h-[44px]">
+        <div className="flex items-center gap-3 shrink-0">
           {backHref && (
             <Link to={backHref} viewTransition>
               <Button
@@ -52,7 +55,9 @@ export function PageHeader({
             {title}
           </Heading>
         </div>
-        {children && <div className="flex items-center gap-2">{children}</div>}
+        {center && <div className="flex-1 min-w-0">{center}</div>}
+        {!center && <div className="flex-1" />}
+        {children && <div className="flex items-center gap-2 shrink-0">{children}</div>}
       </div>
     </header>
   )

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { PageHeader } from '@/components/ui/page-header'
 import { Heading, Text } from '@/components/ui/typography'
 import { api } from '../../convex/_generated/api'
-import { persistQueryCache } from '../router'
+import { idbStore, persistQueryCache } from '../router'
 
 const routeApi = getRouteApi('/settings')
 
@@ -95,7 +95,7 @@ function SettingsPage() {
     setIsClearing(true)
     try {
       // Delete TanStack Query IndexedDB cache
-      await del('tanstack-query-cache')
+      await del('tanstack-query-cache', idbStore)
 
       // Delete all service worker caches
       const cacheNames = await caches.keys()


### PR DESCRIPTION
## Summary
- Namespace IndexedDB store to `the-dahan-codex` to avoid collisions with other apps on the same origin
- Add debounced input to spirit search for smoother typing experience
- Move search bar into page header via new `center` prop on `PageHeader`
- Clean up stale tooling config (remove wrangler/workbox references from .gitignore, .jscpd, knip)

## Test plan
- [ ] Verify spirit search works with debounced input
- [ ] Verify IndexedDB uses `the-dahan-codex` database name (check DevTools > Application > IndexedDB)
- [ ] Verify offline cache sync/clear still works in Settings