### PR TITLE
fix: move outbox sync to layout level

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -40,7 +40,7 @@ Decimal phases appear between their surrounding integers in numeric order.
 - [x] **Phase 6.1: Cleanup TheDahanCodex** - SSR removal, component reuse, dead code cleanup (INSERTED)
 - [x] **Phase 6.2: Fix Code Duplication** - Eliminate jscpd clones, extract shared validators/components (INSERTED)
 - [ ] **Phase 7: Seed Data Management** - Admin tools for spirit seed data
-- [ ] **Phase 8: Spirit & Aspect Data Scraping** - Populate complete spirit data from wiki
+- [x] **Phase 8: Spirit & Aspect Data Scraping** - Populate complete spirit data from wiki
 
 ## Phase Details
 
@@ -470,12 +470,12 @@ Plans:
 
 Plans:
 
-- [ ] 08-01-PLAN.md — Scrape spirit data to JSON (all 37 spirits from wiki)
-- [ ] 08-02-PLAN.md — Scrape aspect data to JSON (all 31 aspects from wiki)
-- [ ] 08-03-PLAN.md — Download spirit and aspect images
-- [ ] 08-04-PLAN.md — Update seed data with scraped information
-- [ ] 08-05-PLAN.md — Preserve openings during reseed
-- [ ] 08-06-PLAN.md — Run reseed and verify data (checkpoint)
+- [x] 08-01-PLAN.md — Scrape spirit data to JSON (all 37 spirits from wiki)
+- [x] 08-02-PLAN.md — Scrape aspect data to JSON (all 31 aspects from wiki)
+- [x] 08-03-PLAN.md — Download spirit and aspect images
+- [x] 08-04-PLAN.md — Update seed data with scraped information
+- [x] 08-05-PLAN.md — Preserve openings during reseed
+- [x] 08-06-PLAN.md — Run reseed and verify data (checkpoint)
 
 ## Cross-Cutting Requirements
 
@@ -517,7 +517,7 @@ development:
 | 6.1 Cleanup TheDahanCodex            | 3/3            | Complete    | 2026-02-01 |
 | 6.2 Fix Code Duplication             | 7/7            | Complete    | 2026-02-02 |
 | 7. Seed Data Management              | 0/TBD          | On Hold     | -          |
-| 8. Spirit & Aspect Data Scraping     | 0/6            | Planned     | -          |
+| 8. Spirit & Aspect Data Scraping     | 6/6            | Complete    | 2026-02-04 |
 
 ---
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,16 +5,16 @@
 See: .planning/PROJECT.md (updated 2025-01-24)
 
 **Core value:** Text-based opening guides for Spirit Island spirits
-**Current focus:** Phase 8 (Spirit & Aspect Data Scraping) in progress
+**Current focus:** All planned phases complete
 
 ## Current Position
 
 Phase: 8 (Spirit & Aspect Data Scraping)
-Plan: 4 of 5 Complete (Wave 3 complete) + Opening guides scraped
-Status: In Progress
-Last activity: 2026-02-02 - Added 17 opening guides from BGG JE/Promo threads and Wiki
+Plan: 6 of 6 Complete
+Status: Complete
+Last activity: 2026-02-04 - Verified DB matches seed data, docs cleanup
 
-Progress: [#####################################-------------] 76% (87/115 plans complete)
+Progress: [##################################################] 100% (93/93 plans complete, excl. abandoned 3.4)
 
 ## Performance Metrics
 
@@ -645,12 +645,13 @@ Phase 6.2 (Fix Code Duplication) complete:
 
 ## Session Continuity
 
-Last session: 2026-02-02
-Stopped at: Added 17 opening guides (BGG JE/Promo threads + Wiki Antistone/breppert)
+Last session: 2026-02-05
+Stopped at: Moved outbox sync to layout level so offline writes sync from any page.
 Resume file: None
 
-**Opening guides added:**
-- BGG Jonah Yonker JE threads: 12 guides (Fractured Days, Shroud, Finder, Downpour, Many Minds, Grinning Trickster, Shifting Memory, Volcano, Lure, Stone's, Starlight, Vengeance)
-- BGG Jonah Yonker promo threads: 2 guides (Serpent, Wildfire)
-- Spirit Island Wiki Antistone/breppert: 3 guides (Rampant Green, Bringer x2)
-- Total openings: 51 → 68 guides from 7 sources
+**Data status:**
+- 37 base spirits seeded from wiki scrape
+- 31 aspects seeded from wiki scrape
+- 68 spirit images downloaded
+- 85 opening guides from 7+ community sources
+- 7 expansions (Base Game through Nature Incarnate)

--- a/.planning/phases/08-spirit-aspect-data-scraping/08-06-SUMMARY.md
+++ b/.planning/phases/08-spirit-aspect-data-scraping/08-06-SUMMARY.md
@@ -1,0 +1,63 @@
+---
+phase: 08-spirit-aspect-data-scraping
+plan: 06
+type: summary
+subsystem: verification
+tags: [reseed, verification, data-quality]
+
+dependency-graph:
+  requires:
+    - "08-01 through 08-05"
+  provides:
+    - "Verified complete spirit library"
+  affects:
+    - "All spirit-related features"
+
+file-tracking:
+  key-files:
+    created: []
+    modified: []
+
+decisions:
+  - id: "skip-reseed-already-current"
+    choice: "Verified DB matches seed data instead of re-running reseed"
+    reason: "DB already contained all 37 spirits, 31 aspects, 85 openings from a previous reseed run"
+
+metrics:
+  duration: "2 min"
+  completed: "2026-02-04"
+---
+
+# Phase 8 Plan 6: Run Reseed and Verify Data Summary
+
+**One-liner:** Verified DB matches seed data — 37 base spirits, 31 aspects, 85 openings, 7 expansions all present and correct.
+
+## What Was Verified
+
+1. **Database counts match seed data** — 37 base spirits, 31 aspects (68 total), 7 expansions
+2. **All base spirit slugs match** between `convex/seedData/spirits.ts` and Convex DB
+3. **All aspect keys match** (baseSpiritSlug/aspectName pairs identical)
+4. **85 openings preserved** from manual curation across 7+ community sources
+5. **68 spirit images** present in `public/spirits/`
+
+## Key Finding
+
+The reseed had already been executed in a prior session. Comparison confirmed the DB was fully current — no re-run needed.
+
+## Verification
+
+- [x] DB spirit count matches seed data (37 base + 31 aspects = 68)
+- [x] All base spirit slugs match between seed file and DB
+- [x] All aspect keys match between seed file and DB
+- [x] 85 openings present in DB
+- [x] 7 expansions present in DB
+
+## Phase 8 Complete
+
+All 6 plans executed:
+- 08-01: Scraped 37 spirits from wiki to JSON
+- 08-02: Scraped 31 aspects from wiki to JSON
+- 08-03: Downloaded 68 spirit/aspect images
+- 08-04: Updated seed data TypeScript file
+- 08-05: Added opening preservation during reseed
+- 08-06: Verified DB matches seed data (this plan)

--- a/src/hooks/use-offline-games.ts
+++ b/src/hooks/use-offline-games.ts
@@ -1,32 +1,28 @@
-import { api } from 'convex/_generated/api'
-import type { Id } from 'convex/_generated/dataModel'
-import { useMutation } from 'convex/react'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { toast } from 'sonner'
+import { useCallback, useEffect, useState } from 'react'
 import type { GameFormData } from '@/components/games/game-form'
-import { useOnlineStatus } from '@/hooks/use-online-status'
-import { transformGameFormToPayload } from '@/lib/game-form-utils'
 import {
   getAllOfflineOps,
   getAllPendingGames,
   type OfflineOperation,
   type PendingGame,
-  removeOfflineOp,
-  removePendingGame,
   savePendingGame,
-  updateOfflineOpStatus,
-  updatePendingGameStatus,
 } from '@/lib/offline-games'
 
 export function usePendingGames() {
   const [pendingGames, setPendingGames] = useState<PendingGame[]>([])
-  const isOnline = useOnlineStatus()
-  const createGame = useMutation(api.games.createGame)
-  const isSyncing = useRef(false)
 
   // Load pending games from IndexedDB on mount
   useEffect(() => {
     getAllPendingGames().then(setPendingGames).catch(console.error)
+  }, [])
+
+  // Refresh when layout-level sync completes
+  useEffect(() => {
+    function handleSynced() {
+      getAllPendingGames().then(setPendingGames).catch(console.error)
+    }
+    window.addEventListener('outbox-synced', handleSynced)
+    return () => window.removeEventListener('outbox-synced', handleSynced)
   }, [])
 
   const saveOfflineGame = useCallback(async (formData: GameFormData) => {
@@ -35,69 +31,24 @@ export function usePendingGames() {
     return game
   }, [])
 
-  const syncPendingGames = useCallback(async () => {
-    if (isSyncing.current) return
-    isSyncing.current = true
-
-    const games = await getAllPendingGames()
-    if (games.length === 0) {
-      isSyncing.current = false
-      return
-    }
-
-    let synced = 0
-    let failed = 0
-
-    for (const game of games) {
-      try {
-        await updatePendingGameStatus(game.id, 'syncing')
-        setPendingGames((prev) =>
-          prev.map((g) => (g.id === game.id ? { ...g, syncStatus: 'syncing' as const } : g)),
-        )
-
-        await createGame(transformGameFormToPayload(game.formData))
-        await removePendingGame(game.id)
-        setPendingGames((prev) => prev.filter((g) => g.id !== game.id))
-        synced++
-      } catch {
-        await updatePendingGameStatus(game.id, 'failed')
-        setPendingGames((prev) =>
-          prev.map((g) => (g.id === game.id ? { ...g, syncStatus: 'failed' as const } : g)),
-        )
-        failed++
-      }
-    }
-
-    if (synced > 0) {
-      toast.success(`Synced ${synced} offline game${synced > 1 ? 's' : ''}`)
-    }
-    if (failed > 0) {
-      toast.error(`Failed to sync ${failed} game${failed > 1 ? 's' : ''}`)
-    }
-
-    isSyncing.current = false
-  }, [createGame])
-
-  // Auto-sync when coming back online
-  useEffect(() => {
-    if (isOnline && pendingGames.length > 0) {
-      syncPendingGames()
-    }
-  }, [isOnline, syncPendingGames, pendingGames.length])
-
-  return { pendingGames, saveOfflineGame, syncPendingGames }
+  return { pendingGames, saveOfflineGame }
 }
 
 export function useOfflineOps() {
   const [offlineOps, setOfflineOps] = useState<OfflineOperation[]>([])
-  const isOnline = useOnlineStatus()
-  const updateGameMutation = useMutation(api.games.updateGame)
-  const deleteGameMutation = useMutation(api.games.deleteGame)
-  const isSyncing = useRef(false)
 
   // Load offline ops from IndexedDB on mount
   useEffect(() => {
     getAllOfflineOps().then(setOfflineOps).catch(console.error)
+  }, [])
+
+  // Refresh when layout-level sync completes
+  useEffect(() => {
+    function handleSynced() {
+      getAllOfflineOps().then(setOfflineOps).catch(console.error)
+    }
+    window.addEventListener('outbox-synced', handleSynced)
+    return () => window.removeEventListener('outbox-synced', handleSynced)
   }, [])
 
   const refreshOps = useCallback(async () => {
@@ -105,55 +56,5 @@ export function useOfflineOps() {
     setOfflineOps(ops)
   }, [])
 
-  const syncOfflineOps = useCallback(async () => {
-    if (isSyncing.current) return
-    isSyncing.current = true
-
-    const ops = await getAllOfflineOps()
-    if (ops.length === 0) {
-      isSyncing.current = false
-      return
-    }
-
-    let synced = 0
-    let failed = 0
-
-    for (const op of ops) {
-      try {
-        await updateOfflineOpStatus(op.id, 'syncing')
-        if (op.type === 'update') {
-          await updateGameMutation({
-            id: op.gameId as Id<'games'>,
-            ...op.data,
-          })
-        } else if (op.type === 'delete') {
-          await deleteGameMutation({ id: op.gameId as Id<'games'> })
-        }
-        await removeOfflineOp(op.id)
-        synced++
-      } catch {
-        await updateOfflineOpStatus(op.id, 'failed')
-        failed++
-      }
-    }
-
-    if (synced > 0) {
-      toast.success(`Synced ${synced} offline change${synced > 1 ? 's' : ''}`)
-    }
-    if (failed > 0) {
-      toast.error(`Failed to sync ${failed} change${failed > 1 ? 's' : ''}`)
-    }
-
-    await refreshOps()
-    isSyncing.current = false
-  }, [updateGameMutation, deleteGameMutation, refreshOps])
-
-  // Auto-sync when coming back online
-  useEffect(() => {
-    if (isOnline && offlineOps.length > 0) {
-      syncOfflineOps()
-    }
-  }, [isOnline, syncOfflineOps, offlineOps.length])
-
-  return { offlineOps, refreshOps, syncOfflineOps }
+  return { offlineOps, refreshOps }
 }

--- a/src/hooks/use-outbox-sync.ts
+++ b/src/hooks/use-outbox-sync.ts
@@ -1,0 +1,104 @@
+import { api } from 'convex/_generated/api'
+import type { Id } from 'convex/_generated/dataModel'
+import { useMutation } from 'convex/react'
+import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import { useOnlineStatus } from '@/hooks/use-online-status'
+import { transformGameFormToPayload } from '@/lib/game-form-utils'
+import {
+  getAllOfflineOps,
+  getAllPendingGames,
+  removeOfflineOp,
+  removePendingGame,
+  updateOfflineOpStatus,
+  updatePendingGameStatus,
+} from '@/lib/offline-games'
+
+/**
+ * Layout-level hook that flushes both outboxes (pending games + offline ops)
+ * when the user is authenticated and back online.
+ *
+ * Dispatches a `outbox-synced` CustomEvent on window so route-level hooks
+ * can refresh their IndexedDB state for display purposes.
+ */
+export function useOutboxSync(isAuthReady: boolean) {
+  const isOnline = useOnlineStatus()
+  const isSyncing = useRef(false)
+
+  const createGame = useMutation(api.games.createGame)
+  const updateGameMutation = useMutation(api.games.updateGame)
+  const deleteGameMutation = useMutation(api.games.deleteGame)
+
+  useEffect(() => {
+    if (!isAuthReady || !isOnline || isSyncing.current) return
+
+    async function sync() {
+      const pendingGames = await getAllPendingGames()
+      const offlineOps = await getAllOfflineOps()
+
+      if (pendingGames.length === 0 && offlineOps.length === 0) return
+
+      isSyncing.current = true
+
+      // --- Sync pending game creations ---
+      let gamesSynced = 0
+      let gamesFailed = 0
+
+      for (const game of pendingGames) {
+        try {
+          await updatePendingGameStatus(game.id, 'syncing')
+          await createGame(transformGameFormToPayload(game.formData))
+          await removePendingGame(game.id)
+          gamesSynced++
+        } catch {
+          await updatePendingGameStatus(game.id, 'failed')
+          gamesFailed++
+        }
+      }
+
+      if (gamesSynced > 0) {
+        toast.success(`Synced ${gamesSynced} offline game${gamesSynced > 1 ? 's' : ''}`)
+      }
+      if (gamesFailed > 0) {
+        toast.error(`Failed to sync ${gamesFailed} game${gamesFailed > 1 ? 's' : ''}`)
+      }
+
+      // --- Sync offline ops (updates + deletes) ---
+      let opsSynced = 0
+      let opsFailed = 0
+
+      for (const op of offlineOps) {
+        try {
+          await updateOfflineOpStatus(op.id, 'syncing')
+          if (op.type === 'update') {
+            await updateGameMutation({
+              id: op.gameId as Id<'games'>,
+              ...op.data,
+            })
+          } else if (op.type === 'delete') {
+            await deleteGameMutation({ id: op.gameId as Id<'games'> })
+          }
+          await removeOfflineOp(op.id)
+          opsSynced++
+        } catch {
+          await updateOfflineOpStatus(op.id, 'failed')
+          opsFailed++
+        }
+      }
+
+      if (opsSynced > 0) {
+        toast.success(`Synced ${opsSynced} offline change${opsSynced > 1 ? 's' : ''}`)
+      }
+      if (opsFailed > 0) {
+        toast.error(`Failed to sync ${opsFailed} change${opsFailed > 1 ? 's' : ''}`)
+      }
+
+      isSyncing.current = false
+
+      // Notify route-level hooks to refresh their IndexedDB state
+      window.dispatchEvent(new CustomEvent('outbox-synced'))
+    }
+
+    sync()
+  }, [isAuthReady, isOnline, createGame, updateGameMutation, deleteGameMutation])
+}

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Outlet, useNavigate } from '@tanstack/react-router'
 import { useEffect } from 'react'
 import { useOnlineStatus } from '@/hooks'
 import { useBackgroundSync } from '@/hooks/use-background-sync'
+import { useOutboxSync } from '@/hooks/use-outbox-sync'
 
 export const Route = createFileRoute('/_authenticated')({
   component: AuthenticatedLayout,
@@ -15,6 +16,9 @@ function AuthenticatedLayout() {
 
   // Auto background sync: games on mount, spirits/openings during idle time
   useBackgroundSync(isLoaded && isSignedIn)
+
+  // Flush offline outboxes (pending games + offline ops) on reconnect
+  useOutboxSync(isLoaded && isSignedIn)
 
   useEffect(() => {
     if (isLoaded && !isSignedIn && isOnline) {


### PR DESCRIPTION
## Summary
- Extract sync logic from `usePendingGames`/`useOfflineOps` into new `useOutboxSync` hook
- Call `useOutboxSync` from `_authenticated` layout so offline writes sync on reconnect from any page
- Route-level hooks listen for `outbox-synced` custom event to refresh their IndexedDB state for display

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm build` clean
- [x] 33/33 E2E tests pass
- [ ] Manual: create game offline → navigate to home → reconnect → verify toast + sync