### PR TITLE
fix: prevent auth guard redirect during loading and clean up theme context

### DIFF
--- a/src/contexts/theme-context.tsx
+++ b/src/contexts/theme-context.tsx
@@ -5,7 +5,6 @@ type Theme = 'light' | 'dark' | 'system'
 interface ThemeContextValue {
   theme: Theme
   setTheme: (theme: Theme) => void
-  resolvedTheme: 'light' | 'dark'
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null)
@@ -38,8 +37,6 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     return (stored as Theme) || 'system'
   })
 
-  const resolvedTheme = theme === 'system' ? getSystemTheme() : theme
-
   const setTheme = useCallback((newTheme: Theme) => {
     setThemeState(newTheme)
     localStorage.setItem(STORAGE_KEY, newTheme)
@@ -47,8 +44,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   // Apply theme on mount and when it changes
   useEffect(() => {
-    applyTheme(resolvedTheme)
-  }, [resolvedTheme])
+    applyTheme(theme === 'system' ? getSystemTheme() : theme)
+  }, [theme])
 
   // Listen for system preference changes when set to 'system'
   useEffect(() => {
@@ -60,11 +57,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     return () => mediaQuery.removeEventListener('change', handler)
   }, [theme])
 
-  return (
-    <ThemeContext.Provider value={{ theme, setTheme, resolvedTheme }}>
-      {children}
-    </ThemeContext.Provider>
-  )
+  return <ThemeContext.Provider value={{ theme, setTheme }}>{children}</ThemeContext.Provider>
 }
 
 export function useTheme(): ThemeContextValue {

--- a/src/routes/games/$id.tsx
+++ b/src/routes/games/$id.tsx
@@ -35,7 +35,7 @@ export const Route = createFileRoute('/games/$id')({
 function GameDetailPage() {
   const { id } = Route.useParams()
   const navigate = useNavigate()
-  const { isAuthenticated } = useConvexAuth()
+  const { isAuthenticated, isLoading } = useConvexAuth()
   const isOnline = useOnlineStatus()
   const queryClient = useQueryClient()
   const [isEditing, setIsEditing] = React.useState(false)
@@ -92,10 +92,10 @@ function GameDetailPage() {
   }, [baseGame, pendingUpdate])
 
   React.useEffect(() => {
-    if (!isAuthenticated) {
+    if (!isLoading && !isAuthenticated) {
       navigate({ to: '/games' })
     }
-  }, [isAuthenticated, navigate])
+  }, [isLoading, isAuthenticated, navigate])
 
   if (!isAuthenticated) return null
 

--- a/src/routes/games/import.tsx
+++ b/src/routes/games/import.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/games/import')({
 
 function ImportPage() {
   const navigate = useNavigate()
-  const { isAuthenticated } = useConvexAuth()
+  const { isAuthenticated, isLoading } = useConvexAuth()
   const [validatedGames, setValidatedGames] = React.useState<ValidatedGame[] | null>(null)
   const fileInputRef = React.useRef<HTMLInputElement>(null)
 
@@ -43,10 +43,10 @@ function ImportPage() {
   })
 
   React.useEffect(() => {
-    if (!isAuthenticated) {
+    if (!isLoading && !isAuthenticated) {
       navigate({ to: '/games' })
     }
-  }, [isAuthenticated, navigate])
+  }, [isLoading, isAuthenticated, navigate])
 
   if (!isAuthenticated) return null
 

--- a/src/routes/games/new.tsx
+++ b/src/routes/games/new.tsx
@@ -17,7 +17,7 @@ export const Route = createFileRoute('/games/new')({
 
 function NewGamePage() {
   const navigate = useNavigate()
-  const { isAuthenticated } = useConvexAuth()
+  const { isAuthenticated, isLoading } = useConvexAuth()
   const isOnline = useOnlineStatus()
   const { saveOfflineGame } = usePendingGames()
 
@@ -32,10 +32,10 @@ function NewGamePage() {
   })
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (!isLoading && !isAuthenticated) {
       navigate({ to: '/games' })
     }
-  }, [isAuthenticated, navigate])
+  }, [isLoading, isAuthenticated, navigate])
 
   if (!isAuthenticated) return null
 


### PR DESCRIPTION
## Summary
- Fix race condition in game routes (`/games/$id`, `/games/new`, `/games/import`) where auth guard redirected to `/games` before auth state finished loading, causing flicker
- Remove unused `resolvedTheme` from theme context interface and provider

## Test plan
- [ ] Navigate to `/games/new` while logged in — no redirect flicker
- [ ] Navigate to `/games/$id` while logged in — page loads normally
- [ ] Import page loads without redirect when authenticated
- [ ] Theme switching still works correctly