### PR TITLE
feat: add view transitions from homepage spirit cards

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -216,8 +216,12 @@ function HomePage() {
                 params={{ slug: spirit.slug }}
                 search={{ opening: undefined }}
                 to="/spirits/$slug"
+                viewTransition
               >
-                <div className="w-full aspect-square overflow-hidden bg-muted">
+                <div
+                  className="w-full aspect-square overflow-hidden bg-muted"
+                  style={{ viewTransitionName: `spirit-image-${spirit.slug}` }}
+                >
                   <img
                     alt={spirit.name}
                     className="w-full h-full object-cover"
@@ -228,7 +232,7 @@ function HomePage() {
                 <div className="p-3 md:p-4">
                   <h3
                     className="text-sm md:text-base leading-tight mb-2 text-card-foreground"
-                    style={{ fontWeight: 600 }}
+                    style={{ viewTransitionName: `spirit-name-${spirit.slug}`, fontWeight: 600 }}
                   >
                     {spirit.name}
                   </h3>


### PR DESCRIPTION
## Summary
- Add `viewTransition` prop and `viewTransitionName` styles to homepage spirit cards
- Reuses the existing `spirit-image-{slug}` / `spirit-name-{slug}` naming convention from the listing/detail pages
- Image and name now morph smoothly when navigating homepage → spirit detail (and back)

## Test plan
- [ ] Navigate from homepage spirit card → detail page: image and name should morph
- [ ] Navigate from spirit listing → detail page: existing morph still works
- [ ] Navigate back from detail → homepage: reverse morph works