### PR TITLE
fix: improve view transitions and scroll restoration

### DIFF
--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -79,7 +79,7 @@ export function BottomNav() {
               key={tab.name}
               to={tab.href as '/spirits' | '/games' | '/settings'}
             >
-              <Icon className={cn('h-5 w-5', isActive && 'text-primary')} />
+              <Icon className="h-5 w-5" />
               <span className={cn('text-xs mt-1', isActive ? 'font-medium' : '')}>{tab.name}</span>
             </Link>
           )

--- a/src/components/spirits/spirit-row.tsx
+++ b/src/components/spirits/spirit-row.tsx
@@ -33,6 +33,8 @@ export function SpiritRow({ spirit, isAspect }: SpiritRowProps) {
     ? `spirit-image-${spirit.slug}-${aspectSlug}`
     : `spirit-image-${spirit.slug}`
 
+  const rowId = isAspect ? `spirit-${spirit.slug}-${aspectSlug}` : `spirit-${spirit.slug}`
+
   return (
     <Link
       className={cn(
@@ -40,7 +42,7 @@ export function SpiritRow({ spirit, isAspect }: SpiritRowProps) {
         'hover:bg-muted/50 active:bg-muted/50 transition-colors duration-150',
         isAspect && 'pl-8 bg-muted/10', // Indent aspects
       )}
-      state={(prev) => ({ ...prev, fromListing: true })}
+      id={rowId}
       to={href}
       viewTransition
     >

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { BookOpen, Compass, Gamepad2, WifiOff } from 'lucide-react'
+import { useRef } from 'react'
 
 export const Route = createFileRoute('/')({
   component: HomePage,
@@ -115,6 +116,9 @@ function OrnamentDivider() {
 }
 
 function HomePage() {
+  const imageRefs = useRef<Record<string, HTMLDivElement | null>>({})
+  const nameRefs = useRef<Record<string, HTMLHeadingElement | null>>({})
+
   return (
     <div className="min-h-screen pb-20 bg-background text-foreground">
       <div className="max-w-[900px] mx-auto px-6 pt-12 md:pt-20">
@@ -213,6 +217,12 @@ function HomePage() {
               <Link
                 className="bg-card border border-border rounded-sm overflow-hidden transition-all duration-200 cursor-default hover:shadow-lg hover:brightness-105 dark:hover:brightness-125 dark:hover:border-accent/40"
                 key={spirit.name}
+                onClick={() => {
+                  const img = imageRefs.current[spirit.slug]
+                  const name = nameRefs.current[spirit.slug]
+                  if (img) img.style.viewTransitionName = `spirit-image-${spirit.slug}`
+                  if (name) name.style.viewTransitionName = `spirit-name-${spirit.slug}`
+                }}
                 params={{ slug: spirit.slug }}
                 search={{ opening: undefined }}
                 to="/spirits/$slug"
@@ -220,7 +230,9 @@ function HomePage() {
               >
                 <div
                   className="w-full aspect-square overflow-hidden bg-muted"
-                  style={{ viewTransitionName: `spirit-image-${spirit.slug}` }}
+                  ref={(el) => {
+                    imageRefs.current[spirit.slug] = el
+                  }}
                 >
                   <img
                     alt={spirit.name}
@@ -232,7 +244,10 @@ function HomePage() {
                 <div className="p-3 md:p-4">
                   <h3
                     className="text-sm md:text-base leading-tight mb-2 text-card-foreground"
-                    style={{ viewTransitionName: `spirit-name-${spirit.slug}`, fontWeight: 600 }}
+                    ref={(el) => {
+                      nameRefs.current[spirit.slug] = el
+                    }}
+                    style={{ fontWeight: 600 }}
                   >
                     {spirit.name}
                   </h3>

--- a/src/routes/spirits.$slug.tsx
+++ b/src/routes/spirits.$slug.tsx
@@ -5,11 +5,9 @@ import {
   Link,
   Outlet,
   useBlocker,
-  useLocation,
   useMatches,
   useNavigate,
   useParams,
-  useRouter,
 } from '@tanstack/react-router'
 import { api } from 'convex/_generated/api'
 import type { Doc } from 'convex/_generated/dataModel'
@@ -78,19 +76,12 @@ export const Route = createFileRoute('/spirits/$slug')({
 function SpiritDetailLayout() {
   const { slug } = Route.useParams()
   const navigate = useNavigate()
-  const router = useRouter()
-  const location = useLocation()
   const matches = useMatches()
   const params = useParams({ strict: false })
 
-  const fromListing = 'fromListing' in location.state && location.state.fromListing === true
   const goBack = useCallback(() => {
-    if (fromListing) {
-      router.history.back()
-    } else {
-      navigate({ to: '/spirits', viewTransition: true })
-    }
-  }, [fromListing, router, navigate])
+    navigate({ to: '/spirits', viewTransition: true })
+  }, [navigate])
 
   // Track tabs visibility for header aspect name display
   const [tabsVisible, setTabsVisible] = useState(true)
@@ -103,6 +94,13 @@ function SpiritDetailLayout() {
 
   // Get current aspect from URL params
   const currentAspect = (params as { aspect?: string }).aspect
+
+  // Store last-viewed spirit in sessionStorage for scroll restoration.
+  // If we add more navigation state, consolidate into a React context instead.
+  useEffect(() => {
+    const key = currentAspect ? `${slug}-${currentAspect}` : slug
+    sessionStorage.setItem('lastViewedSpirit', key)
+  }, [slug, currentAspect])
 
   // Get base spirit with aspects for the tabs
   const { data: spiritData } = useSuspenseQuery(

--- a/src/routes/spirits.index.tsx
+++ b/src/routes/spirits.index.tsx
@@ -2,7 +2,7 @@ import { convexQuery } from '@convex-dev/react-query'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { api } from 'convex/_generated/api'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { z } from 'zod'
 import { FilterChips } from '@/components/spirits/filter-chips'
 import { FilterSheet } from '@/components/spirits/filter-sheet'
@@ -43,6 +43,16 @@ export const Route = createFileRoute('/spirits/')({
 })
 
 function SpiritsPage() {
+  useEffect(() => {
+    const lastViewed = sessionStorage.getItem('lastViewedSpirit')
+    if (lastViewed) {
+      sessionStorage.removeItem('lastViewedSpirit')
+      requestAnimationFrame(() => {
+        document.getElementById(`spirit-${lastViewed}`)?.scrollIntoView({ block: 'center' })
+      })
+    }
+  }, [])
+
   const filters = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
   const { data: spirits } = useSuspenseQuery(


### PR DESCRIPTION
## Summary
- Apply view transition names on click rather than statically, so only the tapped spirit card animates (prevents conflicts when multiple cards have transition names)
- Replace history-based back navigation (`fromListing` state) with sessionStorage scroll restoration — returning to the spirit list scrolls the last-viewed spirit into view
- Remove unused conditional icon coloring in bottom nav

## Test plan
- [ ] Tap a spirit card on homepage → verify smooth view transition to detail page
- [ ] Press back from spirit detail → verify list scrolls to the spirit you were viewing
- [ ] Navigate to spirit list via bottom nav → verify scroll restoration works
- [ ] Check bottom nav icons render correctly on all tabs