### PR TITLE
style: theme Clerk auth widgets to match app design

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -31,6 +31,19 @@ function RootComponent() {
   return (
     <ClerkProvider
       afterSignOutUrl="/"
+      appearance={{
+        variables: {
+          colorPrimary: 'var(--primary)',
+          colorBackground: 'var(--card)',
+          colorText: 'var(--foreground)',
+          colorInputBackground: 'var(--input)',
+          colorInputText: 'var(--foreground)',
+          colorDanger: 'var(--destructive)',
+          colorNeutral: 'var(--muted-foreground)',
+          fontFamily: '"Lora", serif',
+          borderRadius: '0.75rem',
+        },
+      }}
       publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}
       signInFallbackRedirectUrl="/"
       signInUrl="/sign-in"


### PR DESCRIPTION
## Summary
- Map Clerk `appearance.variables` to existing CSS custom properties (parchment/burgundy palette, Lora serif font, matching border radius)
- Dark mode works automatically since values reference CSS variables that switch with the theme

## Test plan
- [ ] Visit `/sign-in` in light mode — verify burgundy primary color, parchment background, serif font
- [ ] Toggle to dark mode — verify colors adapt automatically
- [ ] Visit `/sign-up` — verify same theming applied