### PR TITLE
fix: guard stale async reads and reject impossible calendar dates

### DIFF
--- a/convex/games.ts
+++ b/convex/games.ts
@@ -43,7 +43,9 @@ function validateDate(date: string) {
   if (!ISO_DATE_REGEX.test(date)) {
     throw new Error('date must be in YYYY-MM-DD format')
   }
-  if (Number.isNaN(Date.parse(`${date}T00:00:00Z`))) {
+  const [year, month, day] = date.split('-').map(Number)
+  const d = new Date(Date.UTC(year, month - 1, day))
+  if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) {
     throw new Error('date must be a valid calendar date')
   }
 }

--- a/src/hooks/use-offline-games.ts
+++ b/src/hooks/use-offline-games.ts
@@ -19,20 +19,35 @@ export function usePendingGames() {
       setPendingGames([])
       return
     }
-    const currentUserId = userId
-    getAllPendingGames(currentUserId).then(setPendingGames).catch(console.error)
+    let cancelled = false
+    getAllPendingGames(userId)
+      .then((games) => {
+        if (!cancelled) setPendingGames(games)
+      })
+      .catch(console.error)
+    return () => {
+      cancelled = true
+    }
   }, [isLoaded, userId])
 
   // Refresh when layout-level sync completes
   useEffect(() => {
     if (!isLoaded || !userId) return
+    let cancelled = false
     const currentUserId = userId
 
     function handleSynced() {
-      getAllPendingGames(currentUserId).then(setPendingGames).catch(console.error)
+      getAllPendingGames(currentUserId)
+        .then((games) => {
+          if (!cancelled) setPendingGames(games)
+        })
+        .catch(console.error)
     }
     window.addEventListener('outbox-synced', handleSynced)
-    return () => window.removeEventListener('outbox-synced', handleSynced)
+    return () => {
+      cancelled = true
+      window.removeEventListener('outbox-synced', handleSynced)
+    }
   }, [isLoaded, userId])
 
   const saveOfflineGame = useCallback(
@@ -60,20 +75,35 @@ export function useOfflineOps() {
       setOfflineOps([])
       return
     }
-    const currentUserId = userId
-    getAllOfflineOps(currentUserId).then(setOfflineOps).catch(console.error)
+    let cancelled = false
+    getAllOfflineOps(userId)
+      .then((ops) => {
+        if (!cancelled) setOfflineOps(ops)
+      })
+      .catch(console.error)
+    return () => {
+      cancelled = true
+    }
   }, [isLoaded, userId])
 
   // Refresh when layout-level sync completes
   useEffect(() => {
     if (!isLoaded || !userId) return
+    let cancelled = false
     const currentUserId = userId
 
     function handleSynced() {
-      getAllOfflineOps(currentUserId).then(setOfflineOps).catch(console.error)
+      getAllOfflineOps(currentUserId)
+        .then((ops) => {
+          if (!cancelled) setOfflineOps(ops)
+        })
+        .catch(console.error)
     }
     window.addEventListener('outbox-synced', handleSynced)
-    return () => window.removeEventListener('outbox-synced', handleSynced)
+    return () => {
+      cancelled = true
+      window.removeEventListener('outbox-synced', handleSynced)
+    }
   }, [isLoaded, userId])
 
   const refreshOps = useCallback(async () => {


### PR DESCRIPTION
## Summary
- Add `cancelled` flag pattern to all 4 async `useEffect` hooks in `use-offline-games.ts`, preventing stale IndexedDB reads from overwriting state when `userId` changes mid-flight
- Replace `Date.parse` validation in `convex/games.ts` with round-trip component check so impossible dates like `2024-02-31` are correctly rejected instead of silently rolling over

## Test plan
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm build` — clean build
- [x] Pre-push hooks pass (jscpd, knip, vitest)