### PR TITLE
feat: use neutral app shell fallback for SW navigations

### DIFF
--- a/app-shell.html
+++ b/app-shell.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#1f1510" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="robots" content="noindex,nofollow" />
+    <link rel="icon" id="app-favicon-svg" href="/favicon-light.svg" type="image/svg+xml" />
+    <script src="/theme-init.js"></script>
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <title>The Dahan Codex</title>
+  </head>
+  <body class="min-h-screen bg-background font-body antialiased">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -17,8 +17,8 @@ cleanupOutdatedCaches()
 // Precache all assets injected by vite-plugin-pwa
 precacheAndRoute(self.__WB_MANIFEST)
 
-// SPA navigation fallback: serve precached index.html for all navigation requests
-const navigationHandler = createHandlerBoundToURL('/index.html')
+// App-shell fallback: serve a neutral shell for all SPA navigation requests
+const navigationHandler = createHandlerBoundToURL('/app-shell.html')
 const navigationRoute = new NavigationRoute(navigationHandler, {
   denylist: [/\.[^/]+$/],
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,12 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        appShell: resolve(__dirname, 'app-shell.html'),
+      },
+    },
   },
   plugins: [
     sitemapDate(),


### PR DESCRIPTION
## Summary
- add a dedicated Vite HTML entry at `app-shell.html` for a neutral app shell
- switch Workbox navigation fallback from `/index.html` to `/app-shell.html`
- configure Vite rollup HTML inputs so `app-shell.html` gets production asset rewriting and can be precached

## Why
- removes homepage flash on route reloads for SW-controlled sessions
- keeps prerendered public HTML for first visits and crawlers
- preserves SPA/offline behavior for non-prerendered routes like `/games`

## Validation
- `pnpm check`
- `pnpm build:public`
