### PR TITLE
fix: restore runtime canonical/description updates on app-shell sessions

### DIFF
--- a/app-shell.html
+++ b/app-shell.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#1f1510" />
     <meta name="color-scheme" content="light dark" />
+    <meta
+      name="description"
+      content="Free Spirit Island companion app with turn-by-turn opening guides for all 37 spirits and 31 aspects. Complete spirit reference, game tracker, and offline support."
+    />
+    <link rel="canonical" href="https://dahan-codex.com/" />
     <meta name="robots" content="noindex,nofollow" />
     <link rel="icon" id="app-favicon-svg" href="/favicon-light.svg" type="image/svg+xml" />
     <script src="/theme-init.js"></script>

--- a/src/hooks/use-page-meta.ts
+++ b/src/hooks/use-page-meta.ts
@@ -43,6 +43,18 @@ function ensureMetaTag(selector: string, attrs: Record<string, string>) {
   return tag
 }
 
+function ensureLinkTag(selector: string, attrs: Record<string, string>) {
+  let tag = document.querySelector<HTMLLinkElement>(selector)
+  if (!tag) {
+    tag = document.createElement('link')
+    for (const [key, value] of Object.entries(attrs)) {
+      tag.setAttribute(key, value)
+    }
+    document.head.appendChild(tag)
+  }
+  return tag
+}
+
 /**
  * Update document title and meta tags for the current page.
  * Falls back to defaults when component unmounts.
@@ -64,15 +76,11 @@ export function usePageMeta(optionsOrTitle?: PageMetaOptions | string, legacyDes
 
     document.title = fullTitle
 
-    const metaDescription = document.querySelector('meta[name="description"]')
-    if (metaDescription) {
-      metaDescription.setAttribute('content', description)
-    }
+    const metaDescription = ensureMetaTag('meta[name="description"]', { name: 'description' })
+    metaDescription.setAttribute('content', description)
 
-    const canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]')
-    if (canonical) {
-      canonical.setAttribute('href', canonicalUrl)
-    }
+    const canonical = ensureLinkTag('link[rel="canonical"]', { rel: 'canonical' })
+    canonical.setAttribute('href', canonicalUrl)
 
     const ogTitle = ensureMetaTag('meta[property="og:title"]', { property: 'og:title' })
     ogTitle.setAttribute('content', fullTitle)


### PR DESCRIPTION
## Summary
- ensure `usePageMeta` creates missing `meta[name="description"]` and `link[rel="canonical"]` tags
- add base description/canonical placeholders to `app-shell.html`
- keep route-level runtime metadata updates working when SW serves the app shell

## Why
SW-controlled navigations start from `app-shell.html`. Without placeholders and with update-only logic, description/canonical could be missing in those sessions.

## Validation
- `pnpm check`
