### PR TITLE
fix: move global sync to root and prevent games auth flicker

### DIFF
--- a/e2e/games.spec.ts
+++ b/e2e/games.spec.ts
@@ -22,6 +22,17 @@ test.describe('Game Tracker', () => {
       await expect(page).toHaveURL(/\/games$/)
     })
   })
+
+  test.describe('authenticated', () => {
+    test.skip('does not flash sign-in prompt on /games reload (requires authenticated storage state)', async ({
+      page,
+    }) => {
+      // Enable this assertion once we have an authenticated Playwright fixture.
+      await page.goto('/games')
+      await expect(page.getByText('Track your games')).not.toBeVisible()
+      await expect(page.getByRole('link', { name: /sign in/i })).not.toBeVisible()
+    })
+  })
 })
 
 test.describe('Game Tracker Navigation', () => {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -14,6 +14,8 @@ import { Button } from '../components/ui/button'
 import { Toaster } from '../components/ui/sonner'
 import { EditModeProvider } from '../contexts/edit-mode-context'
 import { ThemeProvider } from '../contexts/theme-context'
+import { useBackgroundSync } from '../hooks/use-background-sync'
+import { useOutboxSync } from '../hooks/use-outbox-sync'
 import { useServiceWorker } from '../hooks/use-service-worker'
 import { clearPersistedQueryCache } from '../router'
 
@@ -86,6 +88,7 @@ function RootComponent() {
       >
         <ConvexProviderWithClerk client={convexClient} useAuth={useAuth}>
           <AuthCacheIsolation queryClient={queryClient} />
+          <GlobalSync />
           <ThemeProvider>
             <EditModeProvider>
               <OfflineIndicator />
@@ -119,6 +122,16 @@ function AuthCacheIsolation({ queryClient }: { queryClient: QueryClient }) {
 
     void clearPersistedQueryCache(queryClient)
   }, [isLoaded, userId, queryClient])
+
+  return null
+}
+
+function GlobalSync() {
+  const { isLoaded, isSignedIn, userId } = useAuth()
+  const isAuthReady = isLoaded && !!isSignedIn
+
+  useBackgroundSync(isAuthReady)
+  useOutboxSync({ isAuthReady, ownerId: userId })
 
   return null
 }

--- a/src/routes/games.tsx
+++ b/src/routes/games.tsx
@@ -1,18 +1,9 @@
-import { useAuth } from '@clerk/clerk-react'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
-import { useBackgroundSync } from '@/hooks/use-background-sync'
-import { useOutboxSync } from '@/hooks/use-outbox-sync'
 
 export const Route = createFileRoute('/games')({
   component: GamesLayout,
 })
 
 function GamesLayout() {
-  const { isLoaded, isSignedIn, userId } = useAuth()
-
-  // Background sync + outbox flush for authenticated users
-  useBackgroundSync(isLoaded && !!isSignedIn)
-  useOutboxSync({ isAuthReady: isLoaded && !!isSignedIn, ownerId: userId })
-
   return <Outlet />
 }

--- a/src/routes/games/index.tsx
+++ b/src/routes/games/index.tsx
@@ -39,7 +39,11 @@ function GamesIndex() {
     ],
   })
 
-  const { isAuthenticated } = useConvexAuth()
+  const { isAuthenticated, isLoading } = useConvexAuth()
+
+  if (isLoading) {
+    return <GamesAuthLoadingState />
+  }
 
   if (!isAuthenticated) {
     return <GamesSignInPrompt />
@@ -65,6 +69,19 @@ function GamesSignInPrompt() {
               Sign In
             </Link>
           </Button>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+function GamesAuthLoadingState() {
+  return (
+    <div className="min-h-screen bg-background">
+      <PageHeader backHref="/" title="Games" />
+      <main className="pb-20">
+        <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+          <p className="text-sm text-muted-foreground">Loading your games...</p>
         </div>
       </main>
     </div>

--- a/src/routes/spirits.$slug.$aspect.tsx
+++ b/src/routes/spirits.$slug.$aspect.tsx
@@ -8,9 +8,9 @@ import { SpiritDetailContent } from './spirits.$slug'
 /**
  * Spirit detail page
  *
- * Offline behavior: This page works offline for spirits that have been
- * synced via Settings > Sync Data. Without prior sync, the page will
- * show a loading state while waiting for Convex connection.
+ * Offline behavior: This page works offline after background spirit sync
+ * has populated local cache. Manual Settings > Sync Data can be used to
+ * force a full refresh.
  */
 export const Route = createFileRoute('/spirits/$slug/$aspect')({
   loader: async ({ context, params }) => {

--- a/src/routes/spirits.$slug.tsx
+++ b/src/routes/spirits.$slug.tsx
@@ -42,9 +42,9 @@ import { cn } from '@/lib/utils'
 /**
  * Spirit detail page
  *
- * Offline behavior: This page works offline for spirits that have been
- * synced via Settings > Sync Data. Without prior sync, the page will
- * show a loading state while waiting for Convex connection.
+ * Offline behavior: This page works offline after background spirit sync
+ * has populated local cache. Manual Settings > Sync Data can be used to
+ * force a full refresh.
  */
 export const Route = createFileRoute('/spirits/$slug')({
   validateSearch: (search: Record<string, unknown>) => ({


### PR DESCRIPTION
## What issue this fixes
Reloading `/games` while already signed in could briefly render the signed-out prompt (`Track your games` + `Sign In`) before auth finished resolving. This created a visible flash of incorrect UI state.

## Root cause
`/games` route index rendered signed-out content as soon as `isAuthenticated` was false, without first waiting for auth readiness (`isLoading`). On reload, auth can be temporarily unresolved, so signed-out UI was shown momentarily.

## What changed
- Added an auth-ready gate in `src/routes/games/index.tsx`:
  - read `isAuthenticated` and `isLoading` from `useConvexAuth()`
  - return a neutral loading shell while `isLoading` is true
  - render sign-in prompt only when auth is resolved and user is unauthenticated
- Added `GamesAuthLoadingState` shell in `src/routes/games/index.tsx` so no guest CTA content is rendered during auth initialization.
- Added a skipped regression test scaffold in `e2e/games.spec.ts` for authenticated reload behavior (to enable once authenticated Playwright storage state is added).

## Additional branch changes included
This branch also includes existing in-progress changes that were already present before this fix, centered on moving sync behavior to a global/root scope:
- `src/routes/games.tsx` (removed layout-local sync hooks)
- `src/routes/__root.tsx` (added `GlobalSync`)
- `src/hooks/use-background-sync.ts` (sync behavior adjustment)
- metadata/title tweaks in spirit route files

## Validation
- `pnpm check` passed
- pre-commit hooks passed (`biome`, `typecheck`)
- pre-push hooks passed (`jscpd`, `knip`, `vitest`)

## User impact
- Signed-in users no longer see a flash of signed-out `/games` UI during reload.
- Signed-out behavior remains unchanged: `/games` still shows sign-in prompt.
