### PR TITLE
fix: defer heavy spirit sync to idle time and improve games auth flow

### DIFF
--- a/src/hooks/use-background-sync.ts
+++ b/src/hooks/use-background-sync.ts
@@ -15,13 +15,23 @@ export function useBackgroundSync(isAuthReady: boolean | undefined) {
   useEffect(() => {
     if (!isOnline) return
 
-    // Public content should be available offline even without auth.
-    syncSpiritsAndOpenings(queryClient).catch((e) =>
-      console.warn('Background spirit sync failed:', e),
-    )
-
+    // Games sync is lightweight — run eagerly when auth is ready.
     if (isAuthReady) {
       syncGames(queryClient).catch((e) => console.warn('Background game sync failed:', e))
+    }
+
+    // Spirit/openings sync is heavy (many batched queries) — defer to idle time
+    // so it doesn't contend with initial route data fetches.
+    const scheduleIdle = window.requestIdleCallback ?? ((cb: () => void) => setTimeout(cb, 2000))
+    const id = scheduleIdle(() => {
+      syncSpiritsAndOpenings(queryClient).catch((e) =>
+        console.warn('Background spirit sync failed:', e),
+      )
+    })
+
+    return () => {
+      const cancelIdle = window.cancelIdleCallback ?? clearTimeout
+      cancelIdle(id)
     }
   }, [isAuthReady, isOnline, queryClient])
 }

--- a/src/routes/games/index.tsx
+++ b/src/routes/games/index.tsx
@@ -1,3 +1,4 @@
+import { useAuth } from '@clerk/clerk-react'
 import { convexQuery } from '@convex-dev/react-query'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, Link } from '@tanstack/react-router'
@@ -39,14 +40,21 @@ function GamesIndex() {
     ],
   })
 
+  const { isLoaded, isSignedIn } = useAuth()
   const { isAuthenticated, isLoading } = useConvexAuth()
+  const isOnline = useOnlineStatus()
 
-  if (isLoading) {
+  if (!isLoaded) {
     return <GamesAuthLoadingState />
   }
 
-  if (!isAuthenticated) {
+  if (!isSignedIn) {
     return <GamesSignInPrompt />
+  }
+
+  // Only block on Convex auth while online to avoid offline reloads getting stuck.
+  if (isOnline && isLoading && !isAuthenticated) {
+    return <GamesAuthLoadingState />
   }
 
   return <AuthenticatedGames />


### PR DESCRIPTION
## Summary
- Defer `syncSpiritsAndOpenings` to idle time via `requestIdleCallback` (with 2s `setTimeout` fallback for Safari) so it doesn't contend with initial route data fetches on app load
- Use Clerk's `useAuth` for faster initial auth resolution on `/games` to eliminate flash of sign-in prompt
- Handle offline auth loading state to prevent stuck loading spinners on offline reload
- Enable authenticated games E2E test with real Clerk test credentials

## Test plan
- [ ] Verify `/games` no longer flashes sign-in prompt on reload when signed in
- [ ] Verify spirit data still syncs for offline use (just deferred)
- [ ] Verify `/games` works correctly when offline