### PR TITLE
fix: prevent toast from hiding behind bottom nav during transitions

### DIFF
--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -48,10 +48,7 @@ export function BottomNav() {
   const currentPath = routerState.location.pathname
 
   return (
-    <nav
-      className="fixed bottom-0 left-0 right-0 z-50 bg-background border-t border-border"
-      style={{ viewTransitionName: 'bottom-nav' }}
-    >
+    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-background border-t border-border">
       <div className="flex items-center justify-around h-16 max-w-lg mx-auto">
         {tabs.map((tab) => {
           const isActive = tab.matchPattern.test(currentPath)

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -158,7 +158,6 @@
 }
 
 /* Keep navigation elements on top during view transitions */
-::view-transition-group(bottom-nav),
 ::view-transition-group(page-header) {
   z-index: 100;
 }


### PR DESCRIPTION
## Summary
- Remove `viewTransitionName` from bottom nav — it's fixed and identical on every page, so participating in view transitions was unnecessary
- This caused Sonner toasts to briefly hide behind the view transition overlay (~300ms) during page navigation
- Clean up orphaned `::view-transition-group(bottom-nav)` CSS rule

## Test plan
- [x] Navigate between pages while a toast is showing — no flicker/overlap
- [x] Page transitions still work (header morphing, content crossfade)
- [x] Build passes