### PR TITLE
fix: simplify games auth to cache-first, fix offline blank pages

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -66,7 +66,7 @@ affecting current work:
 - Convex queries imported via api from convex/\_generated/api
 - Used pathless \_authenticated layout instead of (authenticated) route group
   (TanStack Router constraint)
-- Use useConvexAuth() hook for auth state sync instead of Clerk's useAuth()
+- Game routes use useAuth() (Clerk) for cache-first rendering; _authenticated layout uses useConvexAuth()
 - Admin role via Clerk JWT custom claim: user.public_metadata.isAdmin
 - ClerkProvider > ConvexProviderWithClerk > QueryClientProvider hierarchy
 - Manual Workbox generation via scripts/generate-sw.ts (vite-plugin-pwa

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,8 @@ git checkout feat/phase-<N>-<name>
 
 ## Key Patterns
 
-- Use `useConvexAuth()` for auth state (not Clerk's `useAuth()`)
+- Game routes use `useAuth()` (Clerk) for cache-first rendering — never gate UI on `useConvexAuth()`
+- `_authenticated` layout routes still use `useConvexAuth()` where Convex auth is required
 - Service worker registration is hydration-safe (checks `document.readyState`)
 - Pre-commit hooks run Biome + typecheck automatically
 - Convex types flow from `schema.ts` → `_generated/` → app

--- a/src/routes/games/new.tsx
+++ b/src/routes/games/new.tsx
@@ -1,8 +1,8 @@
+import { useAuth } from '@clerk/clerk-react'
 import { useConvexMutation } from '@convex-dev/react-query'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { api } from 'convex/_generated/api'
-import { useConvexAuth } from 'convex/react'
 import { useEffect } from 'react'
 import { toast } from 'sonner'
 import { GameForm, type GameFormData } from '@/components/games/game-form'
@@ -19,7 +19,7 @@ function NewGamePage() {
   usePageMeta('New Game')
 
   const navigate = useNavigate()
-  const { isAuthenticated, isLoading } = useConvexAuth()
+  const { isLoaded, isSignedIn } = useAuth()
   const isOnline = useOnlineStatus()
   const { saveOfflineGame } = usePendingGames()
 
@@ -34,12 +34,15 @@ function NewGamePage() {
   })
 
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
+    if (isOnline && isLoaded && !isSignedIn) {
       navigate({ to: '/games' })
     }
-  }, [isLoading, isAuthenticated, navigate])
+  }, [isOnline, isLoaded, isSignedIn, navigate])
 
-  if (!isAuthenticated) return null
+  // Offline: always render (saveOfflineGame handles it)
+  // Online + auth loading: brief null while Clerk loads
+  // Online + not signed in: null (redirect fires above)
+  if (isOnline && (!isLoaded || !isSignedIn)) return null
 
   const handleSubmit = async (data: GameFormData) => {
     // Filter out spirits without a spiritId selected (new games require picking from dropdown)


### PR DESCRIPTION
## Summary

- Remove `useConvexAuth()` from all game routes — it blocked rendering until the Clerk→Convex JWT handshake completed (~200-500ms), causing loading flashes for returning users and blank pages when offline
- Game routes now use `useAuth()` (Clerk) with an offline bypass: cached data renders immediately, auth state only decides sign-in prompt vs games view
- Convex backend still enforces auth server-side via `requireAuth()`
- Delete unused `GamesShell` component
- Fix empty state to differentiate "offline with no cache" from "query still loading"
- Update CLAUDE.md and STATE.md to reflect new auth pattern

## Test plan

- [ ] Sign in → visit /games → see games immediately (no flash)
- [ ] Reload page → /games shows cached data instantly
- [ ] Go offline → /games still shows data
- [ ] Go offline → click on a game → detail page renders (was broken)
- [ ] Go offline → click New → form renders (was broken)
- [ ] Go offline → create game → shows "saved offline" toast
- [ ] Go back online → pending games sync
- [ ] Sign out → /games shows sign-in prompt