### PR TITLE
chore: remove Cloudflare account ID from mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,3 @@
 [tools]
 node = "25.2.1"
 pnpm = "10.25.0"
-
-[env]
-# Cloudflare
-CLOUDFLARE_ACCOUNT_ID = "5796b41bb99c92705af706d23abb0989"


### PR DESCRIPTION
## Summary
- Removes hardcoded `CLOUDFLARE_ACCOUNT_ID` from `mise.toml`