### PR TITLE
feat: add GitHub link to credits page

### DIFF
--- a/src/routes/credits.tsx
+++ b/src/routes/credits.tsx
@@ -110,6 +110,27 @@ function CreditsPage() {
           <Text className="mt-1" variant="small">
             Made with care for the Spirit Island community
           </Text>
+          <Text
+            asChild
+            className="mt-1 inline-flex items-center gap-1.5 hover:text-foreground transition-colors cursor-pointer"
+            variant="small"
+          >
+            <a
+              href="https://github.com/FlorinSenoner/the-dahan-codex"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <svg
+                aria-hidden="true"
+                className="h-3.5 w-3.5"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              Source on GitHub
+            </a>
+          </Text>
         </section>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- Add GitHub repository link to the credits page footer
- Use inline SVG for the GitHub icon (lucide-react brand icons are deprecated)
- Use `Text` component with `asChild` for consistent typography

## Test plan
- [ ] Visit /credits and verify GitHub link appears in footer
- [ ] Verify link opens the correct repo in a new tab
- [ ] Verify font matches surrounding footer text