### PR TITLE
chore: relax cache-control headers for better crawlability

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -10,10 +10,10 @@
   Content-Security-Policy: default-src 'self'; script-src 'self' https://*.clerk.accounts.dev https://clerk.dahan-codex.com https://challenges.cloudflare.com https://static.cloudflareinsights.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.convex.cloud https://*.clerk.accounts.dev https://clerk.dahan-codex.com wss://*.convex.cloud https://fonts.gstatic.com https://img.clerk.com; frame-src https://*.clerk.accounts.dev https://clerk.dahan-codex.com https://challenges.cloudflare.com; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
 
 /
-  Cache-Control: no-cache, no-store, must-revalidate
+  Cache-Control: no-cache
 /index.html
-  Cache-Control: no-cache, no-store, must-revalidate
+  Cache-Control: no-cache
 /sw.js
-  Cache-Control: no-cache, no-store, must-revalidate
+  Cache-Control: no-cache
 /assets/*
   Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary
- Relaxes `Cache-Control` from `no-cache, no-store, must-revalidate` to `no-cache` for `/`, `/index.html`, and `/sw.js`
- `no-cache` still ensures revalidation but allows conditional requests (304), which is more efficient and crawler-friendly
- Service worker cache (Cache Storage API) is unaffected by HTTP cache headers

## Test plan
- [ ] Verify site loads correctly after deploy
- [ ] Check response headers show `Cache-Control: no-cache`