### PR TITLE
fix: keep bottom nav and toast above content during view transitions

### DIFF
--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -48,7 +48,10 @@ export function BottomNav() {
   const currentPath = routerState.location.pathname
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-background border-t border-border">
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-50 bg-background border-t border-border"
+      style={{ viewTransitionName: 'bottom-nav' }}
+    >
       <div className="flex items-center justify-around h-16 max-w-lg mx-auto">
         {tabs.map((tab) => {
           const isActive = tab.matchPattern.test(currentPath)

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -2,17 +2,31 @@ import { Toaster as SonnerToaster } from 'sonner'
 
 export function Toaster() {
   return (
-    <SonnerToaster
-      position="bottom-center"
-      toastOptions={{
-        classNames: {
-          toast: 'bg-background border-border',
-          title: 'text-foreground',
-          description: 'text-muted-foreground',
-          actionButton: 'bg-primary text-primary-foreground',
-          cancelButton: 'bg-muted text-muted-foreground',
-        },
+    <div
+      style={{
+        viewTransitionName: 'toast-container',
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 999999999,
+        pointerEvents: 'none',
       }}
-    />
+    >
+      <SonnerToaster
+        position="bottom-center"
+        style={{ pointerEvents: 'auto' }}
+        toastOptions={{
+          classNames: {
+            toast: 'bg-background border-border',
+            title: 'text-foreground',
+            description: 'text-muted-foreground',
+            actionButton: 'bg-primary text-primary-foreground',
+            cancelButton: 'bg-muted text-muted-foreground',
+          },
+        }}
+      />
+    </div>
   )
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -158,8 +158,29 @@
 }
 
 /* Keep navigation elements on top during view transitions */
-::view-transition-group(page-header) {
+::view-transition-group(page-header),
+::view-transition-group(bottom-nav) {
   z-index: 100;
+}
+
+/* Keep toast notifications above navigation during view transitions.
+   viewTransitionName is set via style prop in sonner.tsx.
+   Custom keyframe forces opacity:1 throughout, preventing the default cross-fade
+   from hiding the toast during page transitions. */
+@keyframes vt-persist {
+  from,
+  to {
+    opacity: 1;
+  }
+}
+
+::view-transition-group(toast-container) {
+  z-index: 200;
+}
+
+::view-transition-old(toast-container),
+::view-transition-new(toast-container) {
+  animation-name: vt-persist;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Spirit images were overlaying the bottom nav during page transitions (nav lacked `viewTransitionName`)
- Toast notifications disappeared during transitions (Sonner's `<ol>` conditionally renders, breaking snapshot pairing)
- Wraps Sonner in a persistent fixed div with `viewTransitionName` and adds z-index rules for nav/toast transition groups

## Test plan
- [x] Navigate between spirits list and spirit detail — nav stays on top
- [x] Trigger a toast, then navigate — toast stays visible throughout transition
- [x] Toast still appears above nav bar in normal rendering
- [x] Toasts are still interactive (can be dismissed)
- [x] Typecheck passes